### PR TITLE
Fix na sobrecarga de configuracao e porta quando nao SSL

### DIFF
--- a/src/Hubee.MessageBroker.Sdk/Core/Configurations/ConfigureRabbitMQ.cs
+++ b/src/Hubee.MessageBroker.Sdk/Core/Configurations/ConfigureRabbitMQ.cs
@@ -12,7 +12,11 @@ namespace Hubee.MessageBroker.Sdk.Core.Configurations
             services.AddMassTransit(x => x.AddBus(context => Bus.Factory.CreateUsingRabbitMq(cfg =>
              {
                  cfg.UseHealthCheck(context);
-                 cfg.Host(config.HostName, config.VirtualHost,
+
+                 if (string.IsNullOrEmpty(config.Port))
+                     config.Port = "5672";
+
+                 cfg.Host(config.HostName, ushort.Parse(config.Port), config.VirtualHost,
                       h =>
                       {
                           h.Username(config.UserName);

--- a/src/Hubee.MessageBroker.Sdk/Core/Configurations/ConfigureRabbitMQSsl.cs
+++ b/src/Hubee.MessageBroker.Sdk/Core/Configurations/ConfigureRabbitMQSsl.cs
@@ -13,7 +13,7 @@ namespace Hubee.MessageBroker.Sdk.Core.Configurations
             services.AddMassTransit(x => x.AddBus(context => Bus.Factory.CreateUsingRabbitMq(cfg =>
             {
                 cfg.UseHealthCheck(context);
-                cfg.Host(config.HostName, config.Port, config.VirtualHost,
+                cfg.Host(config.HostName, ushort.Parse(config.Port), config.VirtualHost,
                      h =>
                      {
                          h.Username(config.UserName);

--- a/src/Hubee.MessageBroker.Sdk/Services/EventBusService.cs
+++ b/src/Hubee.MessageBroker.Sdk/Services/EventBusService.cs
@@ -27,6 +27,7 @@ namespace Hubee.MessageBroker.Sdk.Services
             catch (Exception ex)
             {
                 _logger.LogError(ex, ex.Message, ex.StackTrace);
+                throw ex;
             }
         }
 
@@ -39,6 +40,7 @@ namespace Hubee.MessageBroker.Sdk.Services
             catch (Exception ex)
             {
                 _logger.LogError(ex, ex.Message, ex.StackTrace);
+                throw ex;
             }
         }
     }


### PR DESCRIPTION
A propriedade da configuracao para porta e string e nao pega a
sobrecarga de metodo corretamente.

Adicionada possibilidade para preencher a porta quando nao for conexao
SSL.

Fix #2, resolve #3